### PR TITLE
Show widget once per day until submitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Add this to any page, and you're golden: ([**See the demo!**](https://widget.bat
 The goal of this project is to allow anyone with a web site to run their own campaign to save net neutrality. Simply add one line of JavaScript and you're good to go! The modal animation will show up front-and-center on your page, prompting
 visitors to contact Congress and the FCC.
 
-**NOTE: By default, the widget will not display until midnight July 12, so you can add the code right now. If you'd like it to work normally on your site before then, just set a different date (the current date) using the method below.**
+**NOTE: By default, the widget will not display until midnight July 12th (visitor's local time), so you can add the code right now. If you'd like it to display on your site before then, just set a different date using [the method below](#modal-customization-options).**
 
 If you have any problems or questions regarding the widget, please [submit an issue](https://github.com/fightforthefuture/battleforthenet-widget/issues).
 
 
 # How it works
 
-The widget is designed to appear on July 12, 2017, and only once, per user, per device. If you'd like to force it to show up on your page for testing, please reload the page with `#ALWAYS_SHOW_BFTN_WIDGET` at the end of the URL.
+The widget is designed to appear on July 12, 2017, and only once each day until submitted, per user, per device. If you'd like to force it to show up on your page for testing, please reload the page with `#ALWAYS_SHOW_BFTN_WIDGET` at the end of the URL.
 
 Please take a look at [**widget.js**](https://github.com/fightforthefuture/battleforthenet-widget/blob/master/widget.js) if you want to see exactly what you'll
 be embedding on your page.
@@ -24,11 +24,11 @@ be embedding on your page.
 * Compatible with Firefox, Chrome, Safari and Internet Explorer 11+.
 * Embed the widget JavaScript code on your page.
 * Optionally pass in customization parameters (see below), or defaults are used.
-* Widget checks to make sure it should be shown (July 12th 2017 and hasn't been shown to this user before, via cookie). You can override this check for testing purposes.
+* Widget checks to make sure it should be shown on this date, hasn't already been submitted by this user (via cookie) and hasn't already been shown to this user today (via cookie). You can override this check for testing purposes.
 * Widget preloads any images required for the chosen animation.
 * Widget injects a floating `iframe` onto your page. All but the most trivial styles and interactions take place in the `iframe` so as not to interfere with your CSS and JavaScript.
 * Animation displays in floating `iframe`.
-* The user can dismiss the `iframe` and a cookie is written so it won't show again (unless you override).
+* The user can dismiss the `iframe` and a cookie is written so it won't show again today (unless you override).
 
 
 #### Modal customization options:

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ you can pass some properties in to customize the default behavior.
     delay: 1000,
 
     /*
-     * Specify a date on which to display the widget. Defaults to July 12th, 2017 if 
-     * omitted. Useful for testing.
+     * Specify a date on which to start displaying the widget. Defaults to
+     * July 12th, 2017 if omitted. Set `new Date()` to show the widget all the time!
+     * (While still checking cookies to avoid showing it to users who have already
+     * seen it.)
      */
     date: new Date('2017-07-12'),
 

--- a/iframe/script.js
+++ b/iframe/script.js
@@ -160,6 +160,9 @@
   }
 
   function onSuccess(e) {
+    // Send message to parent frame that form was submitted successfully.
+    sendMessage('submit');
+
     if (transitionTimer) clearTimeout(transitionTimer);
 
     // TODO: Error handling

--- a/widget.js
+++ b/widget.js
@@ -139,15 +139,17 @@
     // Should we show the widget, regardless?
     if (!_bftn_options.always_show_widget && window.location.href.indexOf('ALWAYS_SHOW_BFTN_WIDGET') === -1) {
 
-      // Only show once.
-      if (_bftn_util.getCookie('_BFTN_WIDGET_SHOWN')) return;
-
-      // Only show on configured date.
+      // Don't show until configured date.
       var today = new Date();
-      if (today.getFullYear() !== _bftn_options.date.getFullYear() ||
-          today.getMonth() !== _bftn_options.date.getMonth() ||
-          today.getDate() !== _bftn_options.date.getDate()) {
-          return;
+      if (today < _bftn_options.date) {
+        _bftn_util.log('Not time to show the widget yet!');
+        return;
+      }
+
+      // Only show once.
+      if (_bftn_util.getCookie('_BFTN_WIDGET_SHOWN')) {
+        _bftn_util.log('Widget has already been shown.');
+        return;
       }
     }
 

--- a/widget.js
+++ b/widget.js
@@ -77,6 +77,10 @@
           case 'stop':
             animation.stop();
             break;
+          case 'submit':
+            _bftn_util.log('Widget submitted successfully! Setting cookie.');
+            _bftn_util.setCookie('_BFTN_WIDGET_SUBMITTED', 'true', 365);
+            break;
         }
       }, false);
     },
@@ -146,14 +150,20 @@
         return;
       }
 
-      // Only show once.
+      // Only show once per day.
       if (_bftn_util.getCookie('_BFTN_WIDGET_SHOWN')) {
         _bftn_util.log('Widget has already been shown.');
         return;
       }
+
+      // Don't show to users who have already submitted the form!
+      if (_bftn_util.getCookie('_BFTN_WIDGET_SUBMITTED')) {
+        _bftn_util.log('Widget has already been submitted!');
+        return;
+      }
     }
 
-    _bftn_util.setCookie('_BFTN_WIDGET_SHOWN', 'true', 365);
+    _bftn_util.setCookie('_BFTN_WIDGET_SHOWN', 'true', 1);
 
     _bftn_util.injectCSS('_bftn_iframe_css', '#_bftn_iframe { position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; z-index: 20000; }');
 


### PR DESCRIPTION
Widget will be displayed once per day (until submitted) starting on the day of action. This is partially to encourage participants to remove this code from their site after the day of action, and also to facilitate keeping up the momentum for this campaign!