### PR TITLE
Add custom wording and ability to hide close box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,58 +43,53 @@ you can pass some properties in to customize the default behavior.
      * Choose from 'money', 'stop', and 'slow'. Omit this property to get the 
      * default theme.
      */
-    theme: 'slow',
-    
+    theme: 'slow', // @type {string}
+
     /*
-     * Or if you want your own custom theme, specify its properties here.
-     * Specify all four options: `className`, `logos`, `headline`, and `body`.
-     *
-     * className: 'money', 'stop', 'slow', or 'without'.
-     * logos: array that may include 'images/money.png', 'images/stop.png',
-     *   'images/slow.png', 'images/stop_gradient.png', 'images/money_gradient.png'.
-     * headline: your modal headline, as a string.
-     * body: your modal body, as a string.
+     * Or, if you want your own custom theme, specify its properties here.
+     * Unspecified options will fall back to the default values.
      */
     theme: {
-      className: 'money',
-      logos: ['images/money.png', 'images/stop.png'],
-      headline: 'Your headline here.',
-      body: 'Your body here.'
+      className: 'money', // @type {string} will be applied to iframe body tag
+      logos: ['images/money.png', 'images/stop.png'], // @type {Array} img src values
+      headline: 'Your headline here.', // @type {string} modal headline text
+      body: 'Your body here.' // @type {string} modal body text
     },
-    
+
     /*
      * Choose from 'fp' for Free Press, 'dp' for Demand Progress or
      * 'fftf' for Fight for the Future. Omit this property to randomly split
      * form submissions between all organizations in the Battle for the Net 
      * coalition.
      */
-    org: 'fftf',
-    
+    org: 'fftf', // @type {string}
+
     /*
      * Specify a delay (in milliseconds) before showing the widget. Defaults to one 
      * second.
      */
-    delay: 1000,
-    
+    delay: 1000, // @type {number}
+
     /*
      * Specify a date on which to display the widget. Defaults to July 12th, 2017 if 
      * omitted. ISO-8601 dates are UTC time, three-argument dates (with a zero-based
      * month) are local time.
      */
-    date: new Date(2017, 6, 12),
-    
+    date: new Date(2017, 6, 12), // @type {Date}
+
     /*
-     * If you show the modal on your homepage, you should let users close it to access your.
-     * site. But if you launch a new tab to open the modal, closing the modal just leaves the
-     * user staring at a white page. Set this to false to prevent closing the modal.
-     * The user can close the tab to dismiss it. Defaults to true.
+     * If you show the modal on your homepage, you should let users close it to
+     * access your site. However, if you launch a new tab to open the modal, closing
+     * the modal just leaves the user staring at a blank page. Set this to true to
+     * prevent closing the modal - the user can close the tab to dismiss it. Defaults
+     * to false.
      */
-    canClose: true,
-    
+    uncloseable: false, // @type {Boolean}
+
     /*
      * Always show the widget. Useful for testing.
      */
-    always_show_widget: true
+    always_show_widget: true // @type {Boolean}
   };
 </script>
 <script src="https://widget.battleforthenet.com/widget.js" async></script>

--- a/README.md
+++ b/README.md
@@ -44,7 +44,24 @@ you can pass some properties in to customize the default behavior.
      * default theme.
      */
     theme: 'slow',
-
+    
+    /*
+     * Or if you want your own custom theme, specify its properties here.
+     * Specify all four options: `className`, `logos`, `headline`, and `body`.
+     *
+     * className: 'money', 'stop', 'slow', or 'without'.
+     * logos: array that may include 'images/money.png', 'images/stop.png',
+     *   'images/slow.png', 'images/stop_gradient.png', 'images/money_gradient.png'.
+     * headline: your modal headline, as a string.
+     * body: your modal body, as a string.
+     */
+    theme: {
+      className: 'money',
+      logos: ['images/money.png', 'images/stop.png'],
+      headline: 'Your headline here.',
+      body: 'Your body here.'
+    },
+    
     /*
      * Choose from 'fp' for Free Press, 'dp' for Demand Progress or
      * 'fftf' for Fight for the Future. Omit this property to randomly split
@@ -52,20 +69,28 @@ you can pass some properties in to customize the default behavior.
      * coalition.
      */
     org: 'fftf',
-
+    
     /*
      * Specify a delay (in milliseconds) before showing the widget. Defaults to one 
      * second.
      */
     delay: 1000,
-
+    
     /*
      * Specify a date on which to display the widget. Defaults to July 12th, 2017 if 
      * omitted. ISO-8601 dates are UTC time, three-argument dates (with a zero-based
      * month) are local time.
      */
     date: new Date(2017, 6, 12),
-
+    
+    /*
+     * If you show the modal on your homepage, you should let users close it to access your.
+     * site. But if you launch a new tab to open the modal, closing the modal just leaves the
+     * user staring at a white page. Set this to false to prevent closing the modal.
+     * The user can close the tab to dismiss it. Defaults to true.
+     */
+    canClose: true,
+    
     /*
      * Always show the widget. Useful for testing.
      */

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ you can pass some properties in to customize the default behavior.
      * default theme.
      */
     theme: 'slow', // @type {string}
-
+    
     /*
      * Or, if you want your own custom theme, specify its properties here.
      * Unspecified options will fall back to the default values.
@@ -55,7 +55,7 @@ you can pass some properties in to customize the default behavior.
       headline: 'Your headline here.', // @type {string} modal headline text
       body: 'Your body here.' // @type {string} modal body text
     },
-
+    
     /*
      * Choose from 'fp' for Free Press, 'dp' for Demand Progress or
      * 'fftf' for Fight for the Future. Omit this property to randomly split
@@ -63,20 +63,20 @@ you can pass some properties in to customize the default behavior.
      * coalition.
      */
     org: 'fftf', // @type {string}
-
+    
     /*
      * Specify a delay (in milliseconds) before showing the widget. Defaults to one 
      * second.
      */
     delay: 1000, // @type {number}
-
+    
     /*
      * Specify a date on which to display the widget. Defaults to July 12th, 2017 if 
      * omitted. ISO-8601 dates are UTC time, three-argument dates (with a zero-based
      * month) are local time.
      */
     date: new Date(2017, 6, 12), // @type {Date}
-
+    
     /*
      * If you show the modal on your homepage, you should let users close it to
      * access your site. However, if you launch a new tab to open the modal, closing
@@ -85,7 +85,7 @@ you can pass some properties in to customize the default behavior.
      * to false.
      */
     uncloseable: false, // @type {Boolean}
-
+    
     /*
      * Always show the widget. Useful for testing.
      */

--- a/iframe/script.js
+++ b/iframe/script.js
@@ -44,43 +44,57 @@
   }
 
   function getTheme(theme) {
-    if (typeof theme == 'object') {
-      return theme;
-    }
+    var themeObj;
 
-    switch(theme) {
+    switch(typeof theme === 'string' ? theme : '') {
       case 'money':
-        return {
+        themeObj = {
           className: theme,
           logos: ['images/money.png'],
           headline: 'Please upgrade your plan to proceed.',
           body: 'Just kidding. You can still get to this site *for now*. But if the FCC ends net neutrality, your cable company could charge you extra fees just to use the websites and apps you want. We can stop them and keep the Internet open, fast, and awesome if we all contact the U.S. Congress and the FCC, but we only have a few days left.'
         };
+        break;
       case 'stop':
-        return {
+        themeObj = {
           className: theme,
           logos: ['images/stop.png'],
           headline: 'This site has been blocked by your ISP.',
           body: 'Well, not yet. But without net neutrality, cable companies could censor websites, favoring their own business partners. We can stop them and keep the Internet open, fast, and awesome if we all contact the U.S. Congress and the FCC, but we only have a few days left.'
         };
+        break;
       case 'slow':
-        return {
+        themeObj = {
           className: theme,
           logos: ['images/slow.png'],
           headline: 'Sorry, we\'re stuck in the slow lane.',
           body: 'Well, not yet. Cable companies want to get rid of net neutrality, so they can slow sites like ours to a crawl and shake us down for extra fees just to reach you. If they get their way, the Internet will never be the same. We can stop them and keep the web fast, open, and awesome if we all contact the U.S. Congress and the FCC, but we only have a few days left.'
         };
+        break;
+      case 'without':
       default:
-        return {
+        themeObj = {
           className: 'without',
           logos: ['images/slow.png', 'images/stop_gradient.png', 'images/money_gradient.png'],
           headline: 'This is the web without net neutrality.',
           body: 'Cable companies want to get rid of net neutrality. Without it, sites like ours could be censored, slowed down, or forced to charge extra fees. We can stop them and keep the Internet open, fast, and awesome if we all contact Congress and the FCC, but we only have a few days left.'
         };
+        break;
     }
+
+    if (typeof theme == 'object') {
+      var keys = Object.keys(theme);
+      var key;
+      for (var i = 0; i < keys.length; i++) {
+        key = keys[i];
+        themeObj[key] = theme[key];
+      }
+    }
+
+    return themeObj;
   }
 
-  function renderContent(theme, canClose) {
+  function renderContent(theme) {
     document.body.classList.add(theme.className);
 
     // Render logos
@@ -98,12 +112,6 @@
     // Render headline and body copy
     document.getElementById('headline').textContent = theme.headline;
     document.getElementById('content').innerText = theme.body;
-
-    // Optionally disallow closing; undefined is falsey but indicates the default, which is true.
-    if (canClose === false) {
-      var closeButton = document.getElementById('close');
-      closeButton.parentElement.removeChild(closeButton);
-    }
   }
 
   function renderOrgRotation(org) {
@@ -137,6 +145,19 @@
     if (org.donate) donate.setAttribute('href', org.donate);
   }
 
+  function addCloseListeners() {
+    // Add close button listener.
+    document.getElementById('close').addEventListener('mousedown', function(e) {
+      e.preventDefault();
+      sendMessage('stop');
+    });
+
+    document.getElementById('background').addEventListener('mousedown', function(e) {
+      // Ignore events that propagate up
+      if (e.target == document.getElementById('background')) sendMessage('stop');
+    });
+  }
+
   function sendMessage(requestType, data) {
     data || (data = {});
     data.requestType = requestType;
@@ -152,8 +173,14 @@
       init: function(options) {
         for (var k in options) this.options[k] = options[k];
 
-        renderContent(getTheme(this.options.theme), this.options.canClose);
+        renderContent(getTheme(this.options.theme));
         renderOrgRotation(getOrg(this.options.org));
+
+        if (this.options.uncloseable) {
+          document.getElementById('close').classList.add('hidden');
+        } else {
+          addCloseListeners();
+        }
 
         return this;
       },
@@ -298,17 +325,6 @@
 
     xhr.open(call.getAttribute('method'), call.getAttribute('action'), true);
     xhr.send(formData);
-  });
-
-  // Add close button listener.
-  document.getElementById('close').addEventListener('mousedown', function(e) {
-    e.preventDefault();
-    sendMessage('stop');
-  });
-
-  document.getElementById('background').addEventListener('mousedown', function(e) {
-    // Ignore events that propagate up
-    if (e.target == document.getElementById('background')) sendMessage('stop');
   });
 
   // Start animation

--- a/iframe/script.js
+++ b/iframe/script.js
@@ -44,6 +44,10 @@
   }
 
   function getTheme(theme) {
+    if (typeof theme == 'object') {
+      return theme;
+    }
+
     switch(theme) {
       case 'money':
         return {
@@ -76,7 +80,7 @@
     }
   }
 
-  function renderContent(theme) {
+  function renderContent(theme, canClose) {
     document.body.classList.add(theme.className);
 
     // Render logos
@@ -94,6 +98,12 @@
     // Render headline and body copy
     document.getElementById('headline').textContent = theme.headline;
     document.getElementById('content').innerText = theme.body;
+
+    // Optionally disallow closing; undefined is falsey but indicates the default, which is true.
+    if (canClose === false) {
+      var closeButton = document.getElementById('close');
+      closeButton.parentElement.removeChild(closeButton);
+    }
   }
 
   function renderOrgRotation(org) {
@@ -142,7 +152,7 @@
       init: function(options) {
         for (var k in options) this.options[k] = options[k];
 
-        renderContent(getTheme(this.options.theme));
+        renderContent(getTheme(this.options.theme), this.options.canClose);
         renderOrgRotation(getOrg(this.options.org));
 
         return this;

--- a/widget.js
+++ b/widget.js
@@ -21,7 +21,10 @@
         _bftn_util.bindIframeCommunicator(document.getElementById('_bftn_iframe'), this);
       },
       stop: function() {
-        _bftn_util.destroyIframe();
+        var canClose = this.options['canClose'];
+        if (canClose !== false) {
+          _bftn_util.destroyIframe();
+        }
       }
     }
   }

--- a/widget.js
+++ b/widget.js
@@ -21,10 +21,7 @@
         _bftn_util.bindIframeCommunicator(document.getElementById('_bftn_iframe'), this);
       },
       stop: function() {
-        var canClose = this.options['canClose'];
-        if (canClose !== false) {
-          _bftn_util.destroyIframe();
-        }
+        _bftn_util.destroyIframe();
       }
     }
   }


### PR DESCRIPTION
Some organizations including mine, Airbnb, would like to use our own wording in the header
and the body. This PR enables that.

Also, if we want to show a notice that opens this modal in a
new blank tab, we will want to disable closing (because closing the
modal on a blank tab just shows a blank page). This PR also adds
that capability.

The README has been updated to explain how to take advantage of both
these features.

# How was it tested?

I was careful only to use cross-browser-compatible features. I used [`removeChild`](http://caniuse.com/#search=removechild) to remove the Close button.

Ran in Chrome on Mac, tested with an owning page with these options:

```javascript
    var _bftn_options = {
      theme: {
        className: 'money',
        logos: ['images/money.png', 'images/stop.png'],
        headline: 'Your headline here.',
        body: 'Your body here.'
      },

      canClose: false,
      delay: 0,
      always_show_widget: true
    };
```

The result was correct. I also verified that there were no messages in the Chrome debug panel. In this screencast I'm clicking around the modal, trying to close it. It doesn't close because `canClose` is `false`. The blank at the beginning of the screencast is when I refreshed the page to demo it from the start:

![net-neutrality customization](https://user-images.githubusercontent.com/16927/28003533-3d371da0-64f3-11e7-841c-f2e3accbc6a2.gif)


I also tested with `canClose` set to `true` or not set at all; in both cases, the modal was closeable.

