### PR TITLE
Fix Issue #79: On desktop Safari, all fields appear on one row

### DIFF
--- a/iframe/style.css
+++ b/iframe/style.css
@@ -147,9 +147,7 @@ a:hover {
 }
 
 .modal form .flex {
-  min-width: 50%;
-  max-width: 50%;
-  flex: 1;
+  flex: 1 50%;
 }
 
 .modal input,
@@ -163,7 +161,6 @@ a:hover {
   border-radius: 0.2rem;
   font-family: 'Open Sans', sans-serif;
   font-size: 0.9rem;
-  flex: 1;
 }
 
 .modal input[type="checkbox"] {
@@ -173,8 +170,7 @@ a:hover {
 
 .modal input[name="member[first_name]"],
 .modal input[name="member[email]"] {
-  min-width: 43%;
-  max-width: 50%;
+  flex: 1 0 43%;
 }
 
 .modal input[name="member[first_name]"] {
@@ -205,12 +201,11 @@ a:hover {
 }
 
 .modal textarea {
-  min-width: 90%;
-  max-width: 100%;
+  flex: 1 100%;
 }
 
 .modal input[type="submit"] {
-  min-width: 100%;
+  flex: 1 100%;
   margin-bottom: 0;
   padding: 1rem;
   background-color: #49c7ae;
@@ -221,7 +216,6 @@ a:hover {
   text-transform: uppercase;
   letter-spacing: 0.1rem;
   -webkit-appearance: none;
-  flex: 1;
 }
 
 .modal input[type="submit"]:hover {

--- a/iframe/style.css
+++ b/iframe/style.css
@@ -153,7 +153,7 @@ a:hover {
 .modal input,
 .modal textarea {
   min-width: 9%;
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.5rem 0;
   padding: 0.6rem;
   color: #9399c7;
   background-color: transparent;
@@ -438,17 +438,12 @@ body.slow #logos img {
   }
 
   .modal form .flex {
-    min-width: 100%;
-    max-width: 100%;
+    flex: 0 0 100%;
   }
 
   .modal input[name="member[first_name]"],
   .modal input[name="member[email]"] {
-    min-width: 36%;
-  }
-
-  .modal input[name="member[street_address]"] {
-    min-width: 15%;
+    flex: 1 36%;
   }
 
   .modal input[name="member[postcode]"] {
@@ -456,7 +451,7 @@ body.slow #logos img {
   }
 
   .modal input[name="member[phone]"] {
-    min-width: 80%;
+    flex: 1;
     margin-left: 0;
   }
 }
@@ -464,6 +459,6 @@ body.slow #logos img {
 @media (max-width: 375px) {
   .modal input[name="member[first_name]"],
   .modal input[name="member[email]"] {
-    min-width: 33%;
+    flex: 1 33%;
   }
 }

--- a/iframe/style.css
+++ b/iframe/style.css
@@ -77,7 +77,7 @@ a:hover {
 
 .modal {
   margin: 0 auto;
-  width: 520px;
+  width: 530px;
   display: table;
   border-radius: 0.5rem;
   background-color: #0d0a24;
@@ -223,7 +223,8 @@ a:hover {
 }
 
 .modal .prompt input[type="submit"] {
-  min-width: 0;
+  min-width: 20%;
+  max-width: 40%;
   flex: 2;
 }
 
@@ -266,17 +267,15 @@ a:hover {
   margin: 0;
   padding: 0;
   display: flex;
+  flex-wrap: wrap;
   align-items: left;
+  justify-content: space-between;
   list-style-type: none;
 }
 
 .modal footer li {
-  margin-left: 0.5rem;
+  margin: 0 0.25rem 0.5rem;
   flex: 1 0 auto;
-}
-
-.modal footer li:first-child {
-  margin-left: 0;
 }
 
 .modal footer button {
@@ -444,6 +443,27 @@ body.slow #logos img {
   .modal input[name="member[phone_number]"] {
     flex: 1 80%;
     margin-left: 0;
+  }
+}
+
+@media (min-width: 530px) {
+  .modal footer li:first-child {
+    margin-left: 0;
+  }
+
+  .modal footer li:last-child {
+    margin-right: 0;
+  }
+}
+
+@media (max-width: 430px) {
+  .modal input[name="userPhone"] {
+    min-width: 90%;
+    margin: 0 0 0.5rem 0;
+  }
+
+  .modal .prompt input[type="submit"] {
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Fixed the form layout for iOS Safari browser viewports reported in Issue #79. I could not reproduce the desktop Safari issue, but these changes should fix any outliers anyway.

**iPad Retina:**
![ipad retina](https://user-images.githubusercontent.com/1266335/28092856-c5748a84-6649-11e7-9059-c025b6e955a5.png)

**iPhone 5:**
![iphone 5](https://user-images.githubusercontent.com/1266335/28092868-cde1f1d4-6649-11e7-9af1-052d20938a2a.png)

**iPhone 7s:**
![iphone 7s](https://user-images.githubusercontent.com/1266335/28093214-3009c49e-664b-11e7-8b65-18ecdb77f596.png)