### PR TITLE
Makes renderContent more robust

### DIFF
--- a/iframe/script.js
+++ b/iframe/script.js
@@ -113,8 +113,14 @@
     document.getElementById('headline').textContent = theme.headline;
 
     var bodyFragment = document.createDocumentFragment();
-    bodyFragment.textContent = theme.body + ' ';
 
+    var bodyparagraphs = theme.body.split("\n");
+    for (var i = 0; i < bodyparagraphs.length; i++) {
+      var paragraph = document.createElement('p');
+      paragraph.textContent = bodyparagraphs[i];
+      bodyFragment.appendChild(paragraph);
+    }
+    
     var learnMore = document.createElement('a');
     learnMore.setAttribute('href', 'https://www.battleforthenet.com/#widget-learn-more');
     learnMore.setAttribute('target', '_blank');


### PR DESCRIPTION
It now supports multiple paragraphs in the body, merely add them by adding newlines.

It now uses javascript properties that actually exist, no more adding `.textContent` to a dom fragment.

fixes #95
fixes #94

~~I don't actually do much javascript coding, and I haven't tested this, I'll get to that when I put this on my website~~ Tested, here's a demo page that will always show, regardless of cookie: https://tgstation13.org/index.testnn.html

One downside is that the learn more link would now be on a new line. (it actually doesn't look bad like that)

Does appendchild store by value or by reference? If I store and append to the last paragraph element after it's been appended to the body fragment, would that take effect? If so I could make it do that.