### PR TITLE
Fix #93: Dialog keeps appearing on page loads

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -89,7 +89,7 @@
       d.setTime(d.getTime()+(exdays*24*60*60*1000));
 
       var expires = "expires="+d.toGMTString();
-      document.cookie = name + "=" + val + "; " + expires;
+      document.cookie = name + "=" + val + "; " + expires + "; path=/";
     },
 
     getCookie: function(cname) {


### PR DESCRIPTION
Cookie needs `path=/` set, or it only applies to the current directory and subdirectories.